### PR TITLE
Improved allOf/anyOf/oneOf display

### DIFF
--- a/json-schema-viewer.js
+++ b/json-schema-viewer.js
@@ -763,34 +763,32 @@ if (typeof JSV === 'undefined') {
             }
 
             for (key in props) {
-                if (owns.call(props, key)) {
-                    JSV.compileData(props[key],  node, key, true, depth + 1);
+                if (!owns.call(props, key)) {
+                    continue;
                 }
+                JSV.compileData(props[key],  node, key, true, depth + 1);
             }
 
             for (key in all) {
-                if (owns.call(all, key)) {
-                    if(all[key]) {
-                        var allNode = {
-                            name: key,
-                            children: [],
-                            opacity: 0.5,
-                            parentSchema: parent,
-                            schema: schema.$ref || parentSchema(parent)
-                        };
+                if (!owns.call(all, key) || !all[key]) {
+                    continue;
+                }
+                var allNode = {
+                    name: key,
+                    children: [],
+                    opacity: 0.5,
+                    parentSchema: parent,
+                    schema: schema.$ref || parentSchema(parent)
+                };
 
-                        if (node.name === 'item') {
-                            node.parent.children.push(allNode);
-                        } else {
-                            node.children.push(allNode);
-                        }
+                if (node.name === 'item') {
+                    node.parent.children.push(allNode);
+                } else {
+                    node.children.push(allNode);
+                }
 
-                        for (var i = 0; i < all[key].length; i++) {
-                            JSV.compileData(all[key][i], allNode, s.title || key, false, depth + 1);
-                        }
-
-
-                    }
+                for (var i = 0; i < all[key].length; i++) {
+                    JSV.compileData(all[key][i], allNode, s.title || all[key][i].type, false, depth + 1);
                 }
             }
 

--- a/json-schema-viewer.js
+++ b/json-schema-viewer.js
@@ -770,7 +770,10 @@ if (typeof JSV === 'undefined') {
             }
 
             for (key in all) {
-                if (!owns.call(all, key) || !all[key]) {
+                if (!owns.call(all, key)) {
+                    continue;
+                }
+                if (!all[key]) {
                     continue;
                 }
                 var allNode = {


### PR DESCRIPTION
When displaying sub-schemas specified within a combination block, the allOf/anyOf/oneOf keyword is currently repeated if the sub-schema does not have a "title" set. This change proposes using the type as a fallback instead of repeating the keyword. This makes way more sense for a schemas such as:

```
"participants": {
	"type": "array",
	"description": "People involved in the event",
	"items": {
		"oneOf": [
			{
				"type": "object",
				"properties": {
					"role": {
						"type": "string",
						"description": "Role of this participant"
					},
					"name": {
						"type": "string",
						"description": "Participant's name"
					}
				},
				"required": ["name"]
			},
			{
				"type": "string",
				"description": "Participant's name"
			}
		]
	}
}
```

The main change here is `s.title || all[key][i].type` (from: `s.title || key`), the rest are nesting simplifications for readability.