### PR TITLE
doc(README): fix clone repository command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Built using:
 
 ## Installation
 
- 1. Clone repository: `git clone git@github.com:jlblcc/json-schema-viewer.git`
+ 1. Clone repository: `git clone https://github.com/jlblcc/json-schema-viewer.git`
  2. Enter project directory: `cd json-schema-viewer`
  3. Install dependencies via Bower: `bower install`
  4. Install dependencies via NPM: `npm install`


### PR DESCRIPTION
use 'https://github.com/jlblcc/json-schema-viewer.git' URL instead so everybody can download.

'git@github.com:jlblcc/json-schema-viewer.git' involved you have share a public key with github.